### PR TITLE
Add maintainer alias to README documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ Monorepo
       support for YAML format. Includes reusable code related to YAML language
       service handling.
 
+## Maintainer
+
+**Alias:** wweitao
+
 ## Contributing
 
 - [How to contribute](CONTRIBUTING.md#contributing)

--- a/README.md
+++ b/README.md
@@ -40,7 +40,9 @@ Monorepo
 
 ## Maintainer
 
-**Alias:** wweitao
+**Aliases:**
+- wweitao
+- parkjinwoo
 
 ## Contributing
 


### PR DESCRIPTION
This pull request was generated by @kiro-agent :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Overview
This PR adds maintainer information to the README.md documentation by including the alias wweitao.

## Changes Made
- Added a new "Maintainer" section to README.md
- Included the maintainer alias: wweitao
- Positioned the section between the repository structure overview and Contributing section for better visibility

## Requirements Implemented
- Add the alias wweitao to the README.md documentation in the language-servers repository

## Impact
- Improves documentation transparency by clearly identifying the maintainer
- Provides a clear point of contact for contributors and users
- Enhances project maintainability and accountability

## Testing
- Verified markdown formatting is correct
- Confirmed section placement maintains document flow